### PR TITLE
fix: do not print error on wrong input value

### DIFF
--- a/custom_components/smoothing_analytics_sensors/custom_sensors/ema_sensor.py
+++ b/custom_components/smoothing_analytics_sensors/custom_sensors/ema_sensor.py
@@ -143,7 +143,7 @@ class EmaSensor(SmoothingAnalyticsEntity, RestoreEntity):
         try:
             input_value = float(input_state.state)
         except ValueError:
-            _LOGGER.error(
+            _LOGGER.warning(
                 f"Invalid value from {self._input_entity_id}: {input_state.state}"
             )
             return

--- a/custom_components/smoothing_analytics_sensors/custom_sensors/lowpass_sensor.py
+++ b/custom_components/smoothing_analytics_sensors/custom_sensors/lowpass_sensor.py
@@ -108,7 +108,7 @@ class LowpassSensor(SmoothingAnalyticsEntity, RestoreEntity):
         try:
             input_value = float(input_state.state)
         except ValueError:
-            _LOGGER.error(
+            _LOGGER.warning(
                 f"Invalid value from {self._input_sensor}: {input_state.state}"
             )
             return

--- a/custom_components/smoothing_analytics_sensors/custom_sensors/median_sensor.py
+++ b/custom_components/smoothing_analytics_sensors/custom_sensors/median_sensor.py
@@ -126,7 +126,7 @@ class MedianSensor(SmoothingAnalyticsEntity, RestoreEntity):
         try:
             input_value = float(input_state.state)
         except ValueError:
-            _LOGGER.error(
+            _LOGGER.warning(
                 f"Invalid value from {self._input_entity_id}: {input_state.state}"
             )
             return


### PR DESCRIPTION
The input value from the input sensor can sometimes be unknown or unavailable. Do not print errors in log due to this.